### PR TITLE
Add Tumbler dependency as a private service and update Ristretto

### DIFF
--- a/org.xfce.ristretto.yml
+++ b/org.xfce.ristretto.yml
@@ -11,9 +11,6 @@ finish-args:
   # the open dialog is native, but we still need this to open files via the command line
   # and drag and drop, and to delete files
   - --filesystem=host
-  # permissions above include read access to the thumbnails in $HOST_XDG_CACHE_HOME, so
-  # no additional permission is required here
-  - --talk-name=org.freedesktop.thumbnails.Thumbnailer1
   # FIXME: necessary for the property dialog, but not sufficient (there is a fallback):
   # GDBus.Error:org.gtk.GDBus.UnmappedGError.Quark._g_2dfile_2derror_2dquark.Code24: Failed to open display ":99.0"
   - --talk-name=org.xfce.FileManager
@@ -57,12 +54,13 @@ modules:
       - --disable-debug
     sources:
       - type: archive
-        url: https://archive.xfce.org/src/xfce/libxfce4util/4.16/libxfce4util-4.16.0.tar.bz2
-        sha256: 60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83
+        url: https://archive.xfce.org/src/xfce/libxfce4util/4.17/libxfce4util-4.17.1.tar.bz2
+        sha256: 1942151f3c1f3732bc53dd9fd3b936f62067796dc47a33c60a0ad05d933d90f2
         x-checker-data:
           type: anitya
           project-id: 232001
-          stable-only: true
+          # to be reactivated when Tumbler goes to 4.18
+          #stable-only: true
           url-template: https://archive.xfce.org/src/xfce/libxfce4util/$major.$minor/libxfce4util-$version.tar.bz2
 
   - name: xfconf
@@ -247,15 +245,55 @@ modules:
         > /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
       - gdk-pixbuf-query-loaders >> /app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
+  # Tumbler as a private service, just as Xfconf above: stricly speaking it is not a
+  # mandatory dependency, but in the Flatpak context it almost becomes one, and it
+  # allows the application to be more self-contained
+  - name: tumbler
+    cleanup:
+      - /lib/systemd
+      - /share/icons
+    post-install:
+      - sed -i '/^SystemdService=/d' /app/share/dbus-1/services/org.xfce.ristretto.*.service
+    config-opts:
+      - --enable-maintainer-mode
+      - --disable-debug
+      - --disable-cover-thumbnailer
+      - --disable-font-thumbnailer
+      - --disable-ffmpeg-thumbnailer
+      - --disable-gstreamer-thumbnailer
+      - --disable-odf-thumbnailer
+      - --disable-poppler-thumbnailer
+      - --disable-gepub-thumbnailer
+      - TUMBLER_SERVICE_NAME_PREFIX=org.xfce.ristretto
+    sources:
+      - type: git
+        url: https://gitlab.xfce.org/xfce/tumbler.git
+        tag: tumbler-4.17.0
+        commit: 8efa52bd31f96351d1cce2c7cddbb6302679c96a
+        x-checker-data:
+          type: anitya
+          project-id: 5014
+          # to be reactivated when Tumbler goes to 4.18
+          #stable-only: true
+          tag-template: tumbler-$version
+      - type: patch
+        path: patches/Tumbler-Allow-to-choose-an-alternative-service-name-prefix.patch
+
   - name: ristretto
     config-opts:
       - --disable-debug
+      - TUMBLER_SERVICE_NAME_PREFIX=org.xfce.ristretto
     sources:
       - type: archive
-        url: https://archive.xfce.org/src/apps/ristretto/0.12/ristretto-0.12.1.tar.bz2
-        sha256: 13853f9ca18466a8e4788e92c7bde3388a93e8340283568f5dee1a9396ffd7ee
+        url: https://archive.xfce.org/src/apps/ristretto/0.12/ristretto-0.12.2.tar.bz2
+        sha256: 0eee869922ec00a253dafa446c2aad2a2f98e07e1db7262e8337ce9ec2dad969
         x-checker-data:
           type: anitya
           project-id: 8365
           stable-only: true
           url-template: https://archive.xfce.org/src/apps/ristretto/$major.$minor/ristretto-$version.tar.bz2
+      # FIXME: while waiting for Tumbler to be able to emit signals, see
+      # https://github.com/flathub/flathub/issues/2770
+      # https://github.com/flathub/org.xfce.ristretto/pull/7
+      - type: patch
+        path: patches/Emit-signals-manually-instead-of-Tumbler.patch

--- a/patches/Emit-signals-manually-instead-of-Tumbler.patch
+++ b/patches/Emit-signals-manually-instead-of-Tumbler.patch
@@ -1,0 +1,168 @@
+From 6bb46f7ac4cd2fec9211cc3d8357d06cbda3c3f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Sat, 15 Jan 2022 16:56:34 +0100
+Subject: [PATCH] Emit signals manually instead of Tumbler
+
+For some reason, Tumbler cannot emit signals from the flatpak unless you
+specify `--socket=session-bus`, which is not possible in a Flathub
+build.
+
+This patch therefore replaces Tumbler's signal emission with a periodic
+check for the presence of thumbnails for which a request has been sent.
+When the thumbnails are found, everything happens as if Tumbler itself
+had sent the "Ready" signal.
+
+This is suboptimal in various ways, but it should work just fine. A flag
+is provided in case Tumbler is finally able to send signals: if the
+"Finished" signal is received, this patch is disabled.
+
+See also:
+https://github.com/flathub/flathub/issues/2770
+https://github.com/flathub/org.xfce.ristretto/pull/7
+---
+ src/file.c        |  2 +-
+ src/file.h        |  4 ++++
+ src/thumbnailer.c | 61 +++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 66 insertions(+), 1 deletion(-)
+
+diff --git a/src/file.c b/src/file.c
+index b3a87adb..c7cb721b 100644
+--- a/src/file.c
++++ b/src/file.c
+@@ -509,7 +509,7 @@ rstto_file_set_thumbnail_state (RsttoFile *r_file,
+     r_file->priv->thumbnail_states[flavor] = state;
+ }
+ 
+-static const gchar *
++const gchar *
+ rstto_file_get_thumbnail_path (RsttoFile *r_file,
+                                RsttoThumbnailFlavor flavor)
+ {
+diff --git a/src/file.h b/src/file.h
+index bba674cb..9006e5a2 100644
+--- a/src/file.h
++++ b/src/file.h
+@@ -127,6 +127,10 @@ const GdkPixbuf *
+ rstto_file_get_thumbnail (RsttoFile *r_file,
+                           RsttoThumbnailSize size);
+ 
++const gchar *
++rstto_file_get_thumbnail_path (RsttoFile *r_file,
++                               RsttoThumbnailFlavor flavor);
++
+ guint64
+ rstto_file_get_modified_time (RsttoFile *r_file);
+ 
+diff --git a/src/thumbnailer.c b/src/thumbnailer.c
+index 59930309..6d514130 100644
+--- a/src/thumbnailer.c
++++ b/src/thumbnailer.c
+@@ -74,6 +74,10 @@ struct _RsttoThumbnailerPrivate
+     guint                request_timer_ids[RSTTO_THUMBNAIL_FLAVOR_COUNT];
+ 
+     gboolean             show_missing_thumbnailer_error;
++
++    RsttoThumbnailFlavor current_flavor;
++    guint substitute_signal_id;
++    gboolean signals_enabled;
+ };
+ 
+ 
+@@ -118,6 +122,10 @@ rstto_thumbnailer_init (RsttoThumbnailer *thumbnailer)
+         g_signal_connect (thumbnailer->priv->proxy, "finished",
+                           G_CALLBACK (cb_rstto_thumbnailer_request_finished), thumbnailer);
+     }
++
++    thumbnailer->priv->current_flavor = RSTTO_THUMBNAIL_FLAVOR_NORMAL;
++    thumbnailer->priv->substitute_signal_id = 0;
++    thumbnailer->priv->signals_enabled = FALSE;
+ }
+ 
+ 
+@@ -240,6 +248,38 @@ rstto_thumbnailer_get_timer_flavor (RsttoThumbnailer *thumbnailer)
+     return RSTTO_THUMBNAIL_FLAVOR_NORMAL;
+ }
+ 
++static gboolean
++rstto_thumbnailer_substitute_signal (gpointer user_data)
++{
++    RsttoThumbnailer *thumbnailer = user_data;
++    RsttoThumbnailFlavor flavor = thumbnailer->priv->current_flavor;
++    guint n = g_slist_length (thumbnailer->priv->in_process_queues[flavor]);
++    const gchar *uris[n + 1];
++    gint i = 0;
++
++    if (thumbnailer->priv->handles[flavor] == NULL)
++    {
++        thumbnailer->priv->substitute_signal_id = 0;
++        return FALSE;
++    }
++
++    for (GSList *iter = thumbnailer->priv->in_process_queues[flavor]; iter != NULL; iter = iter->next)
++        if (rstto_file_get_thumbnail_path (iter->data, flavor) != NULL)
++            uris[i++] = rstto_file_get_uri (iter->data);
++
++    uris[i] = NULL;
++    cb_rstto_thumbnailer_thumbnail_ready (NULL, GPOINTER_TO_UINT (thumbnailer->priv->handles[flavor]->data),
++                                          uris, user_data);
++
++    if (thumbnailer->priv->in_process_queues[flavor] == NULL)
++    {
++        thumbnailer->priv->substitute_signal_id = 0;
++        return FALSE;
++    }
++
++    return TRUE;
++}
++
+ static gboolean
+ rstto_thumbnailer_queue_request_timer (gpointer user_data)
+ {
+@@ -268,6 +308,15 @@ rstto_thumbnailer_queue_request_timer (gpointer user_data)
+         tumbler_thumbnailer1_call_dequeue_sync (thumbnailer->priv->proxy,
+                                                 GPOINTER_TO_UINT (iter->data), NULL, NULL);
+ 
++    if (! thumbnailer->priv->signals_enabled)
++    {
++        if (thumbnailer->priv->substitute_signal_id != 0)
++            REMOVE_SOURCE (thumbnailer->priv->substitute_signal_id);
++
++        g_slist_free (thumbnailer->priv->handles[flavor]);
++        thumbnailer->priv->handles[flavor] = NULL;
++    }
++
+     /* handle current request, whose size doesn't exceed the number of visible items */
+     for (iter = thumbnailer->priv->queues[flavor], i = 0; iter != NULL; iter = iter->next)
+     {
+@@ -364,9 +413,19 @@ rstto_thumbnailer_queue_request_timer (gpointer user_data)
+         /* TOOO: Nice cleanup */
+     }
+     else
++    {
+         thumbnailer->priv->handles[flavor] =
+             g_slist_prepend (thumbnailer->priv->handles[flavor], GUINT_TO_POINTER (handle));
+ 
++        if (! thumbnailer->priv->signals_enabled)
++        {
++            thumbnailer->priv->current_flavor = flavor;
++            thumbnailer->priv->substitute_signal_id =
++                g_timeout_add (500, rstto_thumbnailer_substitute_signal,
++                               rstto_util_source_autoremove (thumbnailer));
++        }
++    }
++
+     g_free (uris);
+     g_free (mimetypes);
+ 
+@@ -469,6 +528,8 @@ cb_rstto_thumbnailer_request_finished (TumblerThumbnailer1 *proxy,
+ {
+     RsttoThumbnailer *thumbnailer = data;
+ 
++    thumbnailer->priv->signals_enabled = TRUE;
++
+     for (gint n = 0; n < RSTTO_THUMBNAIL_FLAVOR_COUNT; n++)
+         if (g_slist_find (thumbnailer->priv->handles[n], GUINT_TO_POINTER (handle)))
+         {
+-- 
+2.34.1
+

--- a/patches/Tumbler-Allow-to-choose-an-alternative-service-name-prefix.patch
+++ b/patches/Tumbler-Allow-to-choose-an-alternative-service-name-prefix.patch
@@ -1,0 +1,403 @@
+From 4e1619470fdb1e364ad1469e760ba7907d67d936 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20Bonithon?= <gael@xfce.org>
+Date: Sun, 9 Jan 2022 10:59:43 +0100
+Subject: [PATCH] Allow to choose an alternative service name prefix
+
+This is primarily for Flatpak packaging, where a "private service" is
+desirable, although one could imagine using it in other contexts. The
+prefix must be specified via the environment variable
+`TUMBLER_SERVICE_NAME_PREFIX`.
+---
+ .gitignore                                    |  3 ++
+ Makefile.am                                   |  2 +-
+ configure.ac                                  | 24 +++++++++-
+ tumblerd/Makefile.am                          | 46 +++++++++++++------
+ tumblerd/main.c                               |  6 +--
+ tumblerd/org.xfce.Tumbler.Cache1.service.in   |  2 +-
+ tumblerd/org.xfce.Tumbler.Manager1.service.in |  2 +-
+ .../org.xfce.Tumbler.Thumbnailer1.service.in  |  2 +-
+ ....xml => tumbler-cache-service-dbus.xml.in} |  8 ++--
+ tumblerd/tumbler-cache-service.c              |  6 +--
+ ...r-dbus.xml => tumbler-manager-dbus.xml.in} |  7 +--
+ tumblerd/tumbler-manager.c                    |  2 +-
+ ...e-dbus.xml => tumbler-service-dbus.xml.in} |  8 ++--
+ tumblerd/tumbler-service.c                    |  6 +--
+ tumblerd/tumbler-specialized-thumbnailer.c    |  2 +-
+ tumblerd/tumblerd.service.in                  |  2 +-
+ 16 files changed, 82 insertions(+), 46 deletions(-)
+ rename tumblerd/{tumbler-cache-service-dbus.xml => tumbler-cache-service-dbus.xml.in} (77%)
+ rename tumblerd/{tumbler-manager-dbus.xml => tumbler-manager-dbus.xml.in} (70%)
+ rename tumblerd/{tumbler-service-dbus.xml => tumbler-service-dbus.xml.in} (87%)
+
+diff --git a/.gitignore b/.gitignore
+index 19f7441..6060e10 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -35,6 +35,9 @@ tumbler-marshal.[ch]
+ tumbler-cache-service-gdbus.[ch]
+ tumbler-manager-gdbus.[ch]
+ tumbler-service-gdbus.[ch]
++tumbler-cache-service-dbus.xml
++tumbler-manager-dbus.xml
++tumbler-service-dbus.xml
+ *.swp
+ commit-msg
+ *.lo
+diff --git a/Makefile.am b/Makefile.am
+index ea0fb27..867d581 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -34,7 +34,7 @@ distclean-local:
+ 	rm -rf *.spec *.cache *~
+ 
+ distuninstallcheck_listfiles = 						\
+-	find . -type f -print | grep -v ./share/icons/hicolor/icon-theme.cache
++	find . -type f -print | $(GREP) -v ./share/icons/hicolor/icon-theme.cache
+ 
+ .PHONY: ChangeLog
+ 
+diff --git a/configure.ac b/configure.ac
+index 370506d..5917ba8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -96,6 +96,9 @@ AC_PROG_CC()
+ AM_PROG_CC_C_O()
+ AC_PROG_INSTALL()
+ IT_PROG_INTLTOOL([0.35.0], [no-xml])
++AC_PROG_GREP()
++AC_PROG_EGREP()
++AC_PROG_SED()
+ 
+ dnl ***********************
+ dnl *** Prepare libtool ***
+@@ -119,7 +122,7 @@ AC_CHECK_FUNCS([sched_getparam sched_setscheduler getpwnam])
+ dnl ******************************
+ dnl *** Check for i18n support ***
+ dnl ******************************
+-linguas=`ls po/*.po | sed s/.po//g | sed sApo/AA | xargs`
++linguas=$(ls po/*.po | $SED s/.po//g | $SED sApo/AA | xargs)
+ XDT_I18N([$linguas])
+ 
+ dnl *************************
+@@ -151,6 +154,25 @@ PKG_CHECK_MODULES([GMODULE], [gmodule-2.0 >= 2.56.0])
+ PKG_CHECK_MODULES([GTHREAD], [gthread-2.0 >= 2.56.0])
+ XDT_CHECK_PACKAGE([LIBXFCE4UTIL], [libxfce4util-1.0], [4.17.1])
+ 
++dnl ******************************************************************
++dnl *** Alternative service name prefix for e.g. Flatpak packaging ***
++dnl ******************************************************************
++AC_ARG_VAR([TUMBLER_SERVICE_NAME_PREFIX],
++           [Alternative prefix to org.freedesktop.thumbnails for Tumbler services])
++if test -z "$TUMBLER_SERVICE_NAME_PREFIX"; then
++  TUMBLER_SERVICE_NAME_PREFIX='org.freedesktop.thumbnails'
++  AC_SUBST([TUMBLER_SERVICE_FILENAME_PREFIX], [org.xfce.Tumbler])
++else
++  AC_SUBST([TUMBLER_SERVICE_FILENAME_PREFIX], [$TUMBLER_SERVICE_NAME_PREFIX])
++fi
++
++AC_SUBST([TUMBLER_SERVICE_PATH_PREFIX],
++         [$(printf '%s' $TUMBLER_SERVICE_NAME_PREFIX | $SED -E 's%(^|\.)%/%g')])
++AC_DEFINE_UNQUOTED(TUMBLER_SERVICE_NAME_PREFIX, "$TUMBLER_SERVICE_NAME_PREFIX",
++                   Name prefix for Tumbler services)
++AC_DEFINE_UNQUOTED(TUMBLER_SERVICE_PATH_PREFIX, "$TUMBLER_SERVICE_PATH_PREFIX",
++                   Path prefix for Tumbler services)
++
+ dnl *************************
+ dnl *** Check for plugins ***
+ dnl *************************
+diff --git a/tumblerd/Makefile.am b/tumblerd/Makefile.am
+index 1c3e76e..4836bf6 100644
+--- a/tumblerd/Makefile.am
++++ b/tumblerd/Makefile.am
+@@ -92,16 +92,35 @@ service_in_files = 							\
+ 	org.xfce.Tumbler.Manager1.service.in				\
+ 	org.xfce.Tumbler.Thumbnailer1.service.in
+ 
+-service_DATA = $(service_in_files:.service.in=.service)
++service_DATA = $(service_in_files:org.xfce.Tumbler.%.service.in=@TUMBLER_SERVICE_FILENAME_PREFIX@.%.service)
+ 
+ systemd_userdir = $(prefix)/lib/systemd/user
+ systemd_user_in_files = tumblerd.service.in
+ 
+ systemd_user_DATA = $(systemd_user_in_files:.service.in=.service)
+ 
+-%.service: %.service.in
+-	sed -e "s,\@libdir\@,$(libdir),g"				\
+-	    -e "s,\@TUMBLER_VERSION_API\@,$(TUMBLER_VERSION_API),g" < $< > $@
++dbus_xml_in_files = \
++	tumbler-cache-service-dbus.xml.in \
++	tumbler-manager-dbus.xml.in \
++	tumbler-service-dbus.xml.in
++
++dbus_xml_files = $(dbus_xml_in_files:.xml.in=.xml)
++
++@TUMBLER_SERVICE_FILENAME_PREFIX@.%.service: org.xfce.Tumbler.%.service.in
++	$(SED) -e "s,\@libdir\@,$(libdir),g" \
++	       -e "s,\@TUMBLER_VERSION_API\@,$(TUMBLER_VERSION_API),g" \
++	       -e "s,\@TUMBLER_SERVICE_NAME_PREFIX\@,$(TUMBLER_SERVICE_NAME_PREFIX),g" \
++	       -e "s,\@TUMBLER_SERVICE_PATH_PREFIX\@,$(TUMBLER_SERVICE_PATH_PREFIX),g" < $< > $@
++
++tumblerd.service: tumblerd.service.in
++	$(SED) -e "s,\@libdir\@,$(libdir),g" \
++	       -e "s,\@TUMBLER_VERSION_API\@,$(TUMBLER_VERSION_API),g" \
++	       -e "s,\@TUMBLER_SERVICE_NAME_PREFIX\@,$(TUMBLER_SERVICE_NAME_PREFIX),g" \
++	       -e "s,\@TUMBLER_SERVICE_PATH_PREFIX\@,$(TUMBLER_SERVICE_PATH_PREFIX),g" < $< > $@
++
++%.xml: %.xml.in
++	$(SED) -e "s,\@TUMBLER_SERVICE_NAME_PREFIX\@,$(TUMBLER_SERVICE_NAME_PREFIX),g" \
++	       -e "s,\@TUMBLER_SERVICE_PATH_PREFIX\@,$(TUMBLER_SERVICE_PATH_PREFIX),g" < $< > $@
+ 
+ confdir = $(sysconfdir)/xdg/tumbler
+ conf_DATA = \
+@@ -115,12 +134,11 @@ EXTRA_DIST =								\
+ 	$(systemd_user_in_files)					\
+ 	$(service_in_files)						\
+ 	tumbler.rc							\
+-	tumbler-cache-service-dbus.xml					\
+-	tumbler-manager-dbus.xml					\
+-	tumbler-service-dbus.xml
++	$(dbus_xml_in_files)
+ 
+ DISTCLEANFILES =							\
+-	$(tumblerd_built_sources)
++	$(tumblerd_built_sources) \
++	$(dbus_xml_files)
+ 
+ BUILT_SOURCES =								\
+ 	$(tumblerd_built_sources)
+@@ -128,23 +146,23 @@ BUILT_SOURCES =								\
+ tumbler-manager-gdbus.h:
+ tumbler-manager-gdbus.c: tumbler-manager-dbus.xml Makefile
+ 	$(AM_V_GEN) $(GDBUS_CODEGEN) \
+-	--interface-prefix org.freedesktop.thumbnails.Manager1 \
++	--interface-prefix @TUMBLER_SERVICE_NAME_PREFIX@.Manager1 \
+ 	--c-namespace Tumbler 	\
+ 	--generate-c-code tumbler-manager-gdbus \
+-	$(srcdir)/tumbler-manager-dbus.xml
++	tumbler-manager-dbus.xml
+ 
+ tumbler-service-gdbus.h:
+ tumbler-service-gdbus.c: tumbler-service-dbus.xml Makefile
+ 	$(AM_V_GEN) $(GDBUS_CODEGEN) \
+-	--interface-prefix org.freedesktop.thumbnails.Thumbnailer1 \
++	--interface-prefix @TUMBLER_SERVICE_NAME_PREFIX@.Thumbnailer1 \
+ 	--c-namespace Tumbler 	\
+ 	--generate-c-code tumbler-service-gdbus \
+-	$(srcdir)/tumbler-service-dbus.xml
++	tumbler-service-dbus.xml
+ 
+ tumbler-cache-service-gdbus.h:
+ tumbler-cache-service-gdbus.c: tumbler-cache-service-dbus.xml Makefile
+ 	$(AM_V_GEN) $(GDBUS_CODEGEN) \
+-	--interface-prefix org.freedesktop.thumbnails.Cache1 \
++	--interface-prefix @TUMBLER_SERVICE_NAME_PREFIX@.Cache1 \
+ 	--c-namespace Tumbler 	\
+ 	--generate-c-code tumbler-cache-service-gdbus \
+-	$(srcdir)/tumbler-cache-service-dbus.xml
+\ No newline at end of file
++	tumbler-cache-service-dbus.xml
+diff --git a/tumblerd/main.c b/tumblerd/main.c
+index 41b0309..5cc2d66 100644
+--- a/tumblerd/main.c
++++ b/tumblerd/main.c
+@@ -228,7 +228,7 @@ main (int    argc,
+   
+   /* Acquire the cache service dbus name */
+   g_bus_own_name_on_connection (connection,
+-                                "org.freedesktop.thumbnails.Cache1",
++                                TUMBLER_SERVICE_NAME_PREFIX ".Cache1",
+                                 G_BUS_NAME_OWNER_FLAGS_REPLACE,
+                                 NULL, /* We dont need to do anything on name acquired*/
+                                 on_dbus_name_lost,
+@@ -237,7 +237,7 @@ main (int    argc,
+ 
+   /* Acquire the manager dbus name */
+   g_bus_own_name_on_connection (connection,
+-                                "org.freedesktop.thumbnails.Manager1",
++                                TUMBLER_SERVICE_NAME_PREFIX ".Manager1",
+                                 G_BUS_NAME_OWNER_FLAGS_REPLACE,
+                                 NULL, /* We dont need to do anything on name acquired*/
+                                 on_dbus_name_lost,
+@@ -246,7 +246,7 @@ main (int    argc,
+ 
+   /* Acquire the thumbnailer service dbus name */
+   g_bus_own_name_on_connection (connection,
+-                                "org.freedesktop.thumbnails.Thumbnailer1",
++                                TUMBLER_SERVICE_NAME_PREFIX ".Thumbnailer1",
+                                 G_BUS_NAME_OWNER_FLAGS_REPLACE,
+                                 NULL, /* We dont need to do anything on name acquired*/
+                                 on_dbus_name_lost,
+diff --git a/tumblerd/org.xfce.Tumbler.Cache1.service.in b/tumblerd/org.xfce.Tumbler.Cache1.service.in
+index 9221dcc..6e806bf 100644
+--- a/tumblerd/org.xfce.Tumbler.Cache1.service.in
++++ b/tumblerd/org.xfce.Tumbler.Cache1.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+-Name=org.freedesktop.thumbnails.Cache1
++Name=@TUMBLER_SERVICE_NAME_PREFIX@.Cache1
+ Exec=@libdir@/tumbler-@TUMBLER_VERSION_API@/tumblerd
+ SystemdService=tumblerd.service
+diff --git a/tumblerd/org.xfce.Tumbler.Manager1.service.in b/tumblerd/org.xfce.Tumbler.Manager1.service.in
+index cb070b9..c427264 100644
+--- a/tumblerd/org.xfce.Tumbler.Manager1.service.in
++++ b/tumblerd/org.xfce.Tumbler.Manager1.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+-Name=org.freedesktop.thumbnails.Manager1
++Name=@TUMBLER_SERVICE_NAME_PREFIX@.Manager1
+ Exec=@libdir@/tumbler-@TUMBLER_VERSION_API@/tumblerd
+ SystemdService=tumblerd.service
+diff --git a/tumblerd/org.xfce.Tumbler.Thumbnailer1.service.in b/tumblerd/org.xfce.Tumbler.Thumbnailer1.service.in
+index 6dc6d91..7740723 100644
+--- a/tumblerd/org.xfce.Tumbler.Thumbnailer1.service.in
++++ b/tumblerd/org.xfce.Tumbler.Thumbnailer1.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+-Name=org.freedesktop.thumbnails.Thumbnailer1
++Name=@TUMBLER_SERVICE_NAME_PREFIX@.Thumbnailer1
+ Exec=@libdir@/tumbler-@TUMBLER_VERSION_API@/tumblerd
+ SystemdService=tumblerd.service
+diff --git a/tumblerd/tumbler-cache-service-dbus.xml b/tumblerd/tumbler-cache-service-dbus.xml.in
+similarity index 77%
+rename from tumblerd/tumbler-cache-service-dbus.xml
+rename to tumblerd/tumbler-cache-service-dbus.xml.in
+index f297f38..63187af 100644
+--- a/tumblerd/tumbler-cache-service-dbus.xml
++++ b/tumblerd/tumbler-cache-service-dbus.xml.in
+@@ -1,8 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<node name="/org/freedesktop/thumbnails/Cache1">
+-    
+-  <interface name="org.freedesktop.thumbnails.Cache1">
+-   	<annotation name="org.gtk.GDBus.C.Name" value="ExportedCacheService" />
++<node name="@TUMBLER_SERVICE_PATH_PREFIX@/Cache1">
++  <interface name="@TUMBLER_SERVICE_NAME_PREFIX@.Cache1">
++    <annotation name="org.gtk.GDBus.C.Name" value="ExportedCacheService" />
+     <method name="Move">
+       <arg type="as" name="from_uris" direction="in" />
+       <arg type="as" name="to_uris" direction="in" />
+@@ -14,7 +13,6 @@
+     </method>
+ 
+     <method name="Delete">
+-
+       <arg type="as" name="uris" direction="in" />
+     </method>
+ 
+diff --git a/tumblerd/tumbler-cache-service.c b/tumblerd/tumbler-cache-service.c
+index 776c6d5..6b35aac 100644
+--- a/tumblerd/tumbler-cache-service.c
++++ b/tumblerd/tumbler-cache-service.c
+@@ -34,9 +34,9 @@
+ #include <tumblerd/tumbler-cache-service-gdbus.h>
+ #include <tumblerd/tumbler-utils.h>
+ 
+-#define THUMBNAILER_CACHE_PATH    "/org/freedesktop/thumbnails/Cache1"
+-#define THUMBNAILER_CACHE_SERVICE "org.freedesktop.thumbnails.Cache1"
+-#define THUMBNAILER_CACHE_IFACE   "org.freedesktop.thumbnails.Cache1"
++#define THUMBNAILER_CACHE_PATH    TUMBLER_SERVICE_PATH_PREFIX "/Cache1"
++#define THUMBNAILER_CACHE_SERVICE TUMBLER_SERVICE_NAME_PREFIX ".Cache1"
++#define THUMBNAILER_CACHE_IFACE   TUMBLER_SERVICE_NAME_PREFIX ".Cache1"
+ 
+ typedef struct _MoveRequest    MoveRequest;
+ typedef struct _CopyRequest    CopyRequest;
+diff --git a/tumblerd/tumbler-manager-dbus.xml b/tumblerd/tumbler-manager-dbus.xml.in
+similarity index 70%
+rename from tumblerd/tumbler-manager-dbus.xml
+rename to tumblerd/tumbler-manager-dbus.xml.in
+index dc492e7..eda1364 100644
+--- a/tumblerd/tumbler-manager-dbus.xml
++++ b/tumblerd/tumbler-manager-dbus.xml.in
+@@ -1,13 +1,10 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<node name="/org/freedesktop/thumbnails/Manager1">
+-  <interface name="org.freedesktop.thumbnails.Manager1">
+-	
++<node name="@TUMBLER_SERVICE_PATH_PREFIX@/Manager1">
++  <interface name="@TUMBLER_SERVICE_NAME_PREFIX@.Manager1">
+     <annotation name="org.gtk.GDBus.C.Name" value="ExportedManager" />
+-    
+     <method name="Register">
+       <arg type="s" name="uri_scheme" direction="in" />
+       <arg type="s" name="mime_type" direction="in" />
+     </method>
+-  
+   </interface>
+ </node>
+diff --git a/tumblerd/tumbler-manager.c b/tumblerd/tumbler-manager.c
+index 7a128a6..4e62429 100644
+--- a/tumblerd/tumbler-manager.c
++++ b/tumblerd/tumbler-manager.c
+@@ -219,7 +219,7 @@ tumbler_manager_constructed (GObject *object)
+ 
+   g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON(manager->skeleton),
+ 				                            manager->connection,
+-				                            "/org/freedesktop/thumbnails/Manager1",
++				                            TUMBLER_SERVICE_PATH_PREFIX "/Manager1",
+ 				                            &error);
+ 	
+   if (error != NULL)
+diff --git a/tumblerd/tumbler-service-dbus.xml b/tumblerd/tumbler-service-dbus.xml.in
+similarity index 87%
+rename from tumblerd/tumbler-service-dbus.xml
+rename to tumblerd/tumbler-service-dbus.xml.in
+index 4aa77ec..ecb6795 100644
+--- a/tumblerd/tumbler-service-dbus.xml
++++ b/tumblerd/tumbler-service-dbus.xml.in
+@@ -1,9 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<node name="/org/freedesktop/thumbnails/Thumbnailer1">
+-  	<interface name="org.freedesktop.thumbnails.Thumbnailer1">
+-		
+-	<annotation name="org.gtk.GDBus.C.Name" value="ExportedService" />
+-		
++<node name="@TUMBLER_SERVICE_PATH_PREFIX@/Thumbnailer1">
++    <interface name="@TUMBLER_SERVICE_NAME_PREFIX@.Thumbnailer1">
++    <annotation name="org.gtk.GDBus.C.Name" value="ExportedService" />
+     <method name="Queue">
+       <arg type="as" name="uris" direction="in" />
+       <arg type="as" name="mime_types" direction="in" />
+diff --git a/tumblerd/tumbler-service.c b/tumblerd/tumbler-service.c
+index 737791b..bc529eb 100644
+--- a/tumblerd/tumbler-service.c
++++ b/tumblerd/tumbler-service.c
+@@ -40,9 +40,9 @@
+ #include <tumblerd/tumbler-service-gdbus.h>
+ 
+ 
+-#define THUMBNAILER_PATH    "/org/freedesktop/thumbnails/Thumbnailer1"
+-#define THUMBNAILER_SERVICE "org.freedesktop.thumbnails.Thumbnailer1"
+-#define THUMBNAILER_IFACE   "org.freedesktop.thumbnails.Thumbnailer1"
++#define THUMBNAILER_PATH    TUMBLER_SERVICE_PATH_PREFIX "/Thumbnailer1"
++#define THUMBNAILER_SERVICE TUMBLER_SERVICE_NAME_PREFIX ".Thumbnailer1"
++#define THUMBNAILER_IFACE   TUMBLER_SERVICE_NAME_PREFIX ".Thumbnailer1"
+ 
+ 
+ 
+diff --git a/tumblerd/tumbler-specialized-thumbnailer.c b/tumblerd/tumbler-specialized-thumbnailer.c
+index 85d18dd..6c9fbb0 100644
+--- a/tumblerd/tumbler-specialized-thumbnailer.c
++++ b/tumblerd/tumbler-specialized-thumbnailer.c
+@@ -212,7 +212,7 @@ tumbler_specialized_thumbnailer_constructed (GObject *object)
+                            NULL,
+                            thumbnailer->name,
+                            thumbnailer->object_path,
+-                           "org.freedesktop.thumbnails.SpecializedThumbnailer1",
++                           TUMBLER_SERVICE_NAME_PREFIX ".SpecializedThumbnailer1",
+                            NULL,
+                            NULL);
+     
+diff --git a/tumblerd/tumblerd.service.in b/tumblerd/tumblerd.service.in
+index 66c176a..cf26eae 100644
+--- a/tumblerd/tumblerd.service.in
++++ b/tumblerd/tumblerd.service.in
+@@ -5,5 +5,5 @@ Description=Thumbnailing service
+ Type=dbus
+ # This is deliberately the bus name that is the last one to be claimed;
+ # if this is claimed, then everything is ready
+-BusName=org.freedesktop.thumbnails.Thumbnailer1
++BusName=@TUMBLER_SERVICE_NAME_PREFIX@.Thumbnailer1
+ ExecStart=@libdir@/tumbler-@TUMBLER_VERSION_API@/tumblerd
+-- 
+2.34.1
+


### PR DESCRIPTION
This makes the Flatpak application self-contained from a thumbnail
perspective, as it was already from a configuration perspective. Since
thumbnails are no longer searched in `~/.cache` but in
`$XDG_CACHE_HOME`, and the thumbnailing service name must be
configurable at build time, Ristretto 0.12.2 is needed for this to work
properly.

Changes commited upstream in:
https://gitlab.xfce.org/xfce/tumbler/-/commit/b075248d977a6491a6f0f63f5bc67cdb16c3a0f8
https://gitlab.xfce.org/xfce/tumbler/-/commit/7c7bd60f329e351ebdc02c5268364539d8197d29

A patch has also been added temporarily to Ristretto to overcome a
problem of signal emission from Tumbler. See the message of this patch
and:
https://github.com/flathub/flathub/issues/2770
https://github.com/flathub/org.xfce.ristretto/pull/7