### PR TITLE
Bump SDK version to 23.08

### DIFF
--- a/org.xfce.ristretto.yml
+++ b/org.xfce.ristretto.yml
@@ -1,6 +1,6 @@
 app-id: org.xfce.ristretto
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: ristretto
 sdk-extensions:


### PR DESCRIPTION
Required to update webp-pixbuf-loader to 0.2.5, which in turn requires libwebp 1.3.2. See https://github.com/flathub/org.xfce.ristretto/pull/112.