### PR TITLE
update deprecated boost url

### DIFF
--- a/org.xfce.ristretto.yml
+++ b/org.xfce.ristretto.yml
@@ -111,12 +111,12 @@ modules:
             linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
         sources:
           - type: archive
-            url: https://boostorg.jfrog.io/artifactory/main/release/1.87.0/source/boost_1_87_0.tar.gz
+            url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
             sha256: f55c340aa49763b1925ccf02b2e83f35fdcf634c9d5164a2acb87540173c741d
             x-checker-data:
               type: anitya
               project-id: 6845
-              url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${version0}_${version1}_$version2.tar.gz
+              url-template: https://archives.boost.io/release/$version/source/boost_${version0}_${version1}_$version2.tar.gz
 
   - name: libheif
     buildsystem: cmake-ninja


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
